### PR TITLE
fix: update GitHub links after account rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@ This is my personal resume.
 
 ## Important Links
 
-* [Github Actions + Terraform Cloud](https://github.com/patrick-andrew-jain-taylor/github-actions-terraform-cloud-gh-pages)
-* [GitHub Pages Terraform Module](https://github.com/patrick-andrew-jain-taylor/terraform-github-pages)
+* [Github Actions + Terraform Cloud](https://github.com/patrick-andrew-taylor/github-actions-terraform-cloud-gh-pages)
+* [GitHub Pages Terraform Module](https://github.com/patrick-andrew-taylor/terraform-github-pages)

--- a/_config.yml
+++ b/_config.yml
@@ -48,7 +48,7 @@ resume_section_interests:       false
 resume_social_links:
   resume_github_url:            "https://github.com/patrick-andrew-taylor"
   # resume_twitter_url:           "https://twitter.com/pjaintaylor"
-  resume_linkedin_url:          "https://www.linkedin.com/in/pjaintaylor"
+  resume_linkedin_url:          "https://www.linkedin.com/in/patrickandrewtaylor/"
   resume_website_url:           "https://github.com/patrick-andrew-taylor/resume"
   # resume_medium_url:            "https://medium.com/@pjaintaylor"
   resume_pdf_url:               "https://github.com/patrick-andrew-taylor/resume/raw/pdf/webpage/resume.pdf"

--- a/_config.yml
+++ b/_config.yml
@@ -46,12 +46,12 @@ resume_section_interests:       false
 # Resume social links
 # uncomment the options you wish to display, and add your own URL
 resume_social_links:
-  resume_github_url:            "https://github.com/patrick-andrew-jain-taylor"
+  resume_github_url:            "https://github.com/patrick-andrew-taylor"
   # resume_twitter_url:           "https://twitter.com/pjaintaylor"
   resume_linkedin_url:          "https://www.linkedin.com/in/pjaintaylor"
-  resume_website_url:           "https://github.com/patrick-andrew-jain-taylor/resume"
+  resume_website_url:           "https://github.com/patrick-andrew-taylor/resume"
   # resume_medium_url:            "https://medium.com/@pjaintaylor"
-  resume_pdf_url:               "https://github.com/patrick-andrew-jain-taylor/resume/raw/pdf/webpage/resume.pdf"
+  resume_pdf_url:               "https://github.com/patrick-andrew-taylor/resume/raw/pdf/webpage/resume.pdf"
 resume_print_social_links:      true
 
 # Design settings

--- a/_config.yml
+++ b/_config.yml
@@ -47,10 +47,8 @@ resume_section_interests:       false
 # uncomment the options you wish to display, and add your own URL
 resume_social_links:
   resume_github_url:            "https://github.com/patrick-andrew-taylor"
-  # resume_twitter_url:           "https://twitter.com/pjaintaylor"
   resume_linkedin_url:          "https://www.linkedin.com/in/patrickandrewtaylor/"
   resume_website_url:           "https://github.com/patrick-andrew-taylor/resume"
-  # resume_medium_url:            "https://medium.com/@pjaintaylor"
   resume_pdf_url:               "https://github.com/patrick-andrew-taylor/resume/raw/pdf/webpage/resume.pdf"
 resume_print_social_links:      true
 

--- a/_data/links.yml
+++ b/_data/links.yml
@@ -1,5 +1,5 @@
 # links
-- url: "https://recipes.jaintaylor.family/"
+- url: "https://recipes.taylors.family/"
   description: The Jain-Taylor Family Cookbook
 - url: "#"
   description: Personal Resume

--- a/_data/links.yml
+++ b/_data/links.yml
@@ -1,5 +1,5 @@
 # links
 - url: "https://recipes.taylors.family/"
-  description: The Jain-Taylor Family Cookbook
+  description: The Taylor Family Cookbook
 - url: "#"
   description: Personal Resume

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -4,7 +4,7 @@
 - project: The Jain-Taylor Family Cookbook
   role: Developer
   duration: 2020 &mdash; Present
-  url: "https://github.com/patrick-andrew-jain-taylor/jain-taylor-family-cookbook"
+  url: "https://github.com/patrick-andrew-taylor/jain-taylor-family-cookbook"
   description: This is a personal project to maintain our family recipes in source control, using Jekyll & Github Pages to render the updated Markdown.
 
 
@@ -12,5 +12,5 @@
 - project: Resume
   role: Developer
   duration: 2021 &mdash; Present
-  url: "https://github.com/patrick-andrew-jain-taylor/resume"
+  url: "https://github.com/patrick-andrew-taylor/resume"
   description: This is a personal project to keep my resume up to date, using a combination of Github Actions and Terraform Cloud to build the repository, and using Jekyll & Github Pages to render YAML.

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,10 +1,10 @@
 # Projects
 
-# The Jain-Taylor Family Cookbook
-- project: The Jain-Taylor Family Cookbook
+# The Taylor Family Cookbook
+- project: The Taylor Family Cookbook
   role: Developer
   duration: 2020 &mdash; Present
-  url: "https://github.com/patrick-andrew-taylor/jain-taylor-family-cookbook"
+  url: "https://github.com/patrick-andrew-taylor/taylor-family-cookbook"
   description: This is a personal project to maintain our family recipes in source control, using Jekyll & Github Pages to render the updated Markdown.
 
 


### PR DESCRIPTION
## Summary

The GitHub account renamed `patrick-andrew-jain-taylor` → `patrick-andrew-taylor`, the cookbook repo renamed to `taylor-family-cookbook`, and the LinkedIn profile moved to `/in/patrickandrewtaylor`. This sweeps the repo's references:

- **`_config.yml`** — `resume_github_url` (profile links get **no redirect**, so this was a hard 404 on the live resume), `resume_website_url`, `resume_pdf_url`, and `resume_linkedin_url` now point at the new locations. The commented Twitter/Medium entries are removed entirely — those accounts are no longer maintained.
- **`README.md`** — both Terraform project links updated to the new owner.
- **`_data/projects.yml`** — resume repo URL updated; cookbook entry points at `patrick-andrew-taylor/taylor-family-cookbook` (its true current path) and the project title follows the branding to "The Taylor Family Cookbook".
- **`_data/links.yml`** — cookbook link updated to `recipes.taylors.family` and retitled.

Repo redirects would have covered the repo URLs for a while, but they die if the old username gets re-registered — pointing at the real paths removes that dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sWhd45D7cckXzsvYFJtFY